### PR TITLE
Transform rotate

### DIFF
--- a/js/cssGenerator.js
+++ b/js/cssGenerator.js
@@ -38,6 +38,14 @@ const propertyFunctions = [
     var borderStyle = getRandomItemFromArray(borderStyles)
     var borderColor = getRandomRgbString()
     return `border: ${borderStyle} ${borderWidth}px ${borderColor};`
+  },
+
+  /**
+   * Creates a string containing a CSS 'transform' property with a random value.
+   * @return {String} A random CSS 'transform' property
+   */
+  function getRandomTransform () {
+    return `transform: ${getRandomRotation()};`
   }
 ]
 
@@ -76,6 +84,31 @@ function getRandomCssProperty () {
  */
 function getRandomItemFromArray (array) {
   return array[Math.floor(Math.random() * array.length)]
+}
+
+/**
+ * Creates a string containing a random CSS rotate statement, e.g. 'rotateX(180deg)'.
+ * @return {String} A random CSS rotate statement without property or semicolon
+ */
+function getRandomRotation () {
+  switch (Math.floor(Math.random() * 3)) {
+    case 0:
+      return getRandomXRotation()
+    default:
+      return getRandomXRotation()
+  }
+}
+
+/**
+ * Creates a string containing a random CSS rotateX statement, e.g. 'rotateX(180deg)'.
+ * @return {String} A random CSS rotateX statement without property or semicolon
+ */
+function getRandomXRotation () {
+  let rotationInDegrees = 0
+  if (Math.floor(Math.random() * 2)) {
+    rotationInDegrees = 180
+  }
+  return `rotateX(${rotationInDegrees}deg)`
 }
 
 /**

--- a/js/cssGenerator.js
+++ b/js/cssGenerator.js
@@ -94,6 +94,8 @@ function getRandomRotation () {
   switch (Math.floor(Math.random() * 3)) {
     case 0:
       return getRandomXRotation()
+    case 1:
+      return getRandomYRotation()
     default:
       return getRandomXRotation()
   }
@@ -109,6 +111,18 @@ function getRandomXRotation () {
     rotationInDegrees = 180
   }
   return `rotateX(${rotationInDegrees}deg)`
+}
+
+/**
+ * Creates a string containing a random CSS rotateY statement, e.g. 'rotateY(180deg)'.
+ * @return {String} A random CSS rotateY statement without property or semicolon
+ */
+function getRandomYRotation () {
+  let rotationInDegrees = 0
+  if (Math.floor(Math.random() * 2)) {
+    rotationInDegrees = 180
+  }
+  return `rotateY(${rotationInDegrees}deg)`
 }
 
 /**


### PR DESCRIPTION
Added `getRandomTransform` function to `cssGenerator.js` which for now supports to different rotate properties.
`getRandomRotation` is setup to expect three different rotate properties (`rotateX, rotateY and rotateZ`, but I have specifically left out `rotateZ` for now because it seemed to wild to use with just any values.
`getRandomXRotation` and `getRandomYRotation` both return either 0 or 180 degree rotations as doing random between 360 degrees sometimes hides element.
